### PR TITLE
better for psycopg2 cursor

### DIFF
--- a/builder/data_helper.py
+++ b/builder/data_helper.py
@@ -18,7 +18,8 @@ def get_query_cursor(sql):
     conn = connect_to_sqllite()
     c = conn.cursor()
 
-    return c.execute(sql)
+    c.execute(sql)
+    return c
 
 
 def get_data_frame(sql, columns):


### PR DESCRIPTION
psycopg2's `execute` returns `None`. I think returning cursor is better for both sqlite3 and psycopg2 ;-)

http://initd.org/psycopg/docs/cursor.html#cursor.execute