### PR TITLE
Fix error on analytics cluster view

### DIFF
--- a/analytics/views.py
+++ b/analytics/views.py
@@ -132,7 +132,10 @@ def lda(request):
 def cluster(request, cluster_id):
 
     members = Cluster.objects.filter(cluster_id=cluster_id)
-    member_ratings = Rating.objects.filter(user_id__in=members.values('user_id'))
+    member_values = list(map(str, members.values_list(
+        'user_id', flat=True).order_by('user_id')))
+    member_ratings = Rating.objects.filter(
+        user_id__in=member_values)
     movies = Movie.objects.filter(movie_id__in=member_ratings.values('movie_id'))
 
     ratings = {r.movie_id: r for r in member_ratings}


### PR DESCRIPTION
`user_id` in the `Cluster` model is an integer field and `user_id` of `Ratings` is a char field. That's why when you try to visit a page of cluster (for example `http://localhost:8000/analytics/cluster/3/`) Django was throwing an error because the code was comparing integers and strings. Now, integer list is converted to a string list first and strings are compared to strings.