### PR TITLE
fixed issued with the wrong weights being assigned to events.

### DIFF
--- a/builder/implicit_ratings_calculator.py
+++ b/builder/implicit_ratings_calculator.py
@@ -90,7 +90,7 @@ def calculate_implicit_ratings_for_user(user_id):
     ratings = dict()
     for k, v in agg_data .items():
 
-        rating = w1 * v['buy'] + w2 * v['details'] + w3 * v['moredetails']
+        rating = w1 * v['buy'] + w3 * v['details'] + w2 * v['moredetails']
         max_rating = max(max_rating, rating)
 
         ratings[k] = rating


### PR DESCRIPTION
Hello Kim,

I have started going over the code and the simulated data and trying to replicate it all in python-pandas in a local repo to ensure I understand all the steps and can derive things on my own.

I have come across this issue where in the textbook, as well as line 58 of `implicit_rating_calculator.py`, you designate `"moredetails"` as `w2` (50), but in line 93 you have it switched with `"details"`. 

There's one other issue I will create a PR for once I find it, but in listing 4.1 of the textbook, you do a `count(CASE...` using 'moredetails' as the even, when in fact in should be 'moreDetails`. This is causing the simulated data to contain all zeroes under `moreDetails` when counting events for users. I have checked this locally and can confirm. This will skew all implicit ratings.

Cheers!